### PR TITLE
simplify end material (closes #36)

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,11 @@
+2017-10-04  Dirk Eddelbuettel  <edd@debian.org>
+
+	* inst/rmarkdown/templates/pdf/resources/template.tex: Condition
+	acknowledgements, remove matmethods and pnasbreak
+
+	* vignettes/pinp.Rmd (numbersections): Turn on numbered sections
+	(up to one level) which makes less of a hash of the outline
+
 2017-09-20  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.0.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pinp
 Type: Package
 Title: 'pinp' is not 'PNAS'
-Version: 0.0.2
-Date: 2017-09-20
+Version: 0.0.2.1
+Date: 2017-10-04
 Author: Dirk Eddelbuettel and James Balamuta
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: A 'PNAS'-alike style for 'rmarkdown', derived from the

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -71,9 +71,11 @@ $endif$
 
 $body$
 
-\showmatmethods
+%\showmatmethods
+$if(acknowledgements)$
 \showacknow
-\pnasbreak 
+$endif$
+%\pnasbreak 
 
 $if(natbib)$
 $if(bibliography)$

--- a/vignettes/pinp.Rmd
+++ b/vignettes/pinp.Rmd
@@ -52,10 +52,10 @@ fontsize: 9pt
 #one_sided: true
 
 # Optional: Enable section numbering, default is unnumbered
-#numbersections: true
+numbersections: true
 
 # Optional: Specify the depth of section number, default is 5
-#secnumdepth: 5
+secnumdepth: 3
 
 # Optional: Bibliography 
 #bibliography: pinp
@@ -115,7 +115,6 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
 
 ---
-
 
 # Introduction 
 


### PR DESCRIPTION
Possible fix for #36.  Looks good to me on the pinp vignette itself.  Reference now move into the column which seems to make a lot of typsetting easier.  

We could bring the old `\pnasbreak` back with a yaml header yes/no var (or even parameterize the points to vskip -- two different definitions uses in the two different pnas sub files in rticles).  I don't think it is worth it.