### PR TITLE
document frontmatter in help page

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2017-10-24  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/pinp.R: Added documentation for YAML frontmater
+	* man/pinp.Rd: Idem
+
+	* inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd: Cleanup
+
 2017-10-23  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/rmarkdown/templates/pdf/resources/template.tex: Support

--- a/R/pinp.R
+++ b/R/pinp.R
@@ -11,6 +11,51 @@
 #' @return R Markdown output format to pass to
 #' \code{\link[rmarkdown:render]{render}}
 #'
+#' @section Document options:
+#' Various aspects of pdf document can be customized by setting either standard \pkg{rmarkdown}
+#' options, or any of the following options (which are shown in alphabetical order) in the 
+#' document metadata:
+#'
+#' \describe{
+#'   \item{\code{abstract}}{(Optional but recommended) A free-format abstract summarizing the
+#'   document.}
+#'   \item{\code{acknowledgements}}{(Optional) A free-format entry which will be placed at the
+#'   end of the document.}
+#'   \item{\code{address}}{(Mandatory) YAML list with entries for \code{code} and \code{address}.  
+#'   The former matches the \code{affiliation} field of the \code{author} entry; the letter can be
+#'   a free-format text giving, say, department and university along with an email address.}
+#'   \item{\code{author}}{(Mandatory) YAML list with entries for \code{name} and \code{affiliation}.
+#'   The latter is matched to the \code{code} entry in \code{address} option.}
+#'   \item{\code{bibliography}}{(Optional) Name of a \code{.bib} file, suffix can be omitted;
+#'   defaut is no bibliography.}
+#'   \item{\code{doi}}{(Optional but recommended) A free-format entry suitable for a doi or url
+#'   referencing the document or its underlying code.}
+#'   \item{\code{fontsize}}{(Optional) Document fontsize, default is 9pt.}
+#'   \item{\code{footer_contents}}{(Optional) A free-format entry for text placed in the footer,
+#'   useful to associate with a package or volume, default is \sQuote{Package Vignette}.}
+#'   \item{\code{headercolor}}{(Optional) Color code (in hexadecimal notation) for the title and 
+#'   section headers, default is blue tone matching the R logo: \code{185FAF}.}
+#'   \item{\code{keywords}}{(Optional) Keywords describing the document, supplied as a list.}
+#'   \item{\code{lead_author_surnames}}{(Optional but recommended) A free-format entry for a short
+#'   author description placed in the footer.}
+#'   \item{\code{lineno}}{(Optional) Logical value to select line number display, may only work
+#'   in one-column mode, default is false.}
+#'   \item{\code{linkcolor}}{(Optional) Color code (in hexadecimal notation) for the urls and reference
+#'   links, default is a light blue tone from the PNAS style: \code{000065}.}
+#'   \item{\code{numbersections}}{(Optional) Logical value to select numbered section headers,
+#'   default is false.}
+#'   \item{\code{one_column}}{(Optional) Logical value to select one-column mode, default is false.}
+#'   \item{\code{one_sided}}{(Optional) Logical value to select one-sided format, default is false.}
+#'   \item{\code{output}}{(Mandatory) Entry to tell \code{rmarkdown} to render via \code{pinp};
+#'   must be \code{pinp::pinp}.}
+#'   \item{\code{secnumdepth}}{(Optional) Level of (LaTeX) section levels to number, default is 5.}
+#'   \item{\code{title}}{(Mandatory) document title, no default.}
+#'   \item{\code{title}}{(Optional) Logical value to select a \sQuote{Draft} watermark to be
+#'   added (though figures tend to render above it, default is false.}
+#' }
+#'
+#' The vignette source shows several of these options in use, and also describes some of the options.
+#'
 #' @examples
 #' \dontrun{
 #' rmarkdown::draft("MyArticle.Rmd", template = "pdf", package = "pinp")

--- a/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
@@ -80,7 +80,7 @@ vignette: >
   %\VignetteEngine{knitr::rmarkdown}
 ---
 
-## Introduction {#intro .unnumbered}
+## Introduction 
 
 This *pinp is not PNAS* template started when the introduction to
 [Rcpp](http://dirk.eddelbuettel.com/code/rcpp.html) by \cite{PeerJ:Rcpp} 
@@ -105,7 +105,7 @@ Please note that LaTeX typesetting in two-column mode with several
 floating objects can be fragile.  You may need to iterate.
 
 
-## Author Affiliations {#author-affiliations .unnumbered}
+## Author Affiliations 
 
 Per common academic best practice, you can include your department,
 institution, and complete address, with the ZIP/postal code, for each
@@ -125,16 +125,9 @@ We support several options via the YAML header
 - Setting a free-form author field used on the inside footer;
 - Optional _Draft_ watermarking;
 
-<!-- ## Format {#format .unnumbered}
-
-Many authors find it useful to organize their manuscripts with the
-following order of sections; Title, Author Affiliation, Keywords,
-Abstract, Significance Statement, Results, Discussion, Materials and
-methods, Acknowledgments, and References. Other orders and headings are
-permitted. -->
 
 
-## References {#references .unnumbered}
+## References 
 
 Here we differ from PNAS and suggest natbib. References will appear in
 author-year form. Use `\citet{}`, `\citep{}`, etc as usual.
@@ -143,7 +136,7 @@ We default to the `jss.bst` style. To switch to a different bibliography
 style, please use `biblio-style: style` in the YAML header.
 
 
-## Inline R Code {#inliner .unnumbered}
+## Inline R Code 
 
 The PNAS sample included a fixed PNG image here, but this document prefers
 to show the results and embedding of _R_ code. 
@@ -162,7 +155,7 @@ Here we use a standard knitr bloc with explicit options for
 - the caption (`fig.cap`) as shown above.
 
 
-## Digital Figures {#sec:figures .unnumbered}
+## Digital Figures 
 
 Markdown, Pandoc and LaTeX support `.eps` and `.pdf` files.
 
@@ -197,7 +190,7 @@ This file is then included via standard LaTeX commands.
 \end{figure*}
 
 
-## Typeset Code (But Do Not Run It) {#typeset .unnumbered}
+## Typeset Code (But Do Not Run It) 
 
 We can also just show code.
 
@@ -212,7 +205,7 @@ with `r` as the language choice.  Similarly, _many_ other languages
 can be typset directly simply by relying on pandoc.
 
 
-## Single column equations {#single-column-equations .unnumbered}
+## Single column equations 
 
 Authors may use 1- or 2-column equations in their article, according to
 their preference.

--- a/man/pinp.Rd
+++ b/man/pinp.Rd
@@ -22,6 +22,53 @@ R Markdown output format to pass to
 \description{
 Format suitable for attractive two-column pdf vignettes
 }
+\section{Document options}{
+
+Various aspects of pdf document can be customized by setting either standard \pkg{rmarkdown}
+options, or any of the following options (which are shown in alphabetical order) in the 
+document metadata:
+
+\describe{
+  \item{\code{abstract}}{(Optional but recommended) A free-format abstract summarizing the
+  document.}
+  \item{\code{acknowledgements}}{(Optional) A free-format entry which will be placed at the
+  end of the document.}
+  \item{\code{address}}{(Mandatory) YAML list with entries for \code{code} and \code{address}.  
+  The former matches the \code{affiliation} field of the \code{author} entry; the letter can be
+  a free-format text giving, say, department and university along with an email address.}
+  \item{\code{author}}{(Mandatory) YAML list with entries for \code{name} and \code{affiliation}.
+  The latter is matched to the \code{code} entry in \code{address} option.}
+  \item{\code{bibliography}}{(Optional) Name of a \code{.bib} file, suffix can be omitted;
+  defaut is no bibliography.}
+  \item{\code{doi}}{(Optional but recommended) A free-format entry suitable for a doi or url
+  referencing the document or its underlying code.}
+  \item{\code{fontsize}}{(Optional) Document fontsize, default is 9pt.}
+  \item{\code{footer_contents}}{(Optional) A free-format entry for text placed in the footer,
+  useful to associate with a package or volume, default is \sQuote{Package Vignette}.}
+  \item{\code{headercolor}}{(Optional) Color code (in hexadecimal notation) for the title and 
+  section headers, default is blue tone matching the R logo: \code{185FAF}.}
+  \item{\code{keywords}}{(Optional) Keywords describing the document, supplied as a list.}
+  \item{\code{lead_author_surnames}}{(Optional but recommended) A free-format entry for a short
+  author description placed in the footer.}
+  \item{\code{lineno}}{(Optional) Logical value to select line number display, may only work
+  in one-column mode, default is false.}
+  \item{\code{linkcolor}}{(Optional) Color code (in hexadecimal notation) for the urls and reference
+  links, default is a light blue tone from the PNAS style: \code{000065}.}
+  \item{\code{numbersections}}{(Optional) Logical value to select numbered section headers,
+  default is false.}
+  \item{\code{one_column}}{(Optional) Logical value to select one-column mode, default is false.}
+  \item{\code{one_sided}}{(Optional) Logical value to select one-sided format, default is false.}
+  \item{\code{output}}{(Mandatory) Entry to tell \code{rmarkdown} to render via \code{pinp};
+  must be \code{pinp::pinp}.}
+  \item{\code{secnumdepth}}{(Optional) Level of (LaTeX) section levels to number, default is 5.}
+  \item{\code{title}}{(Mandatory) document title, no default.}
+  \item{\code{title}}{(Optional) Logical value to select a \sQuote{Draft} watermark to be
+  added (though figures tend to render above it, default is false.}
+}
+
+The vignette source shows several of these options in use, and also describes some of the options.
+}
+
 \examples{
 \dontrun{
 rmarkdown::draft("MyArticle.Rmd", template = "pdf", package = "pinp")

--- a/pinp.Rproj
+++ b/pinp.Rproj
@@ -14,3 +14,4 @@ LaTeX: pdfLaTeX
 
 BuildType: Package
 PackageInstallArgs: --no-multiarch --with-keep.source
+PackageRoxygenize: rd


### PR DESCRIPTION
In linl we added documentation for the frontmatter in the Rd which seems like a good idea.  So ditto here.

Minor cleanup to skeleton.Rd as well.