### PR TITLE
Add option skip_final_break to disable \pnasbreak

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,6 @@
 .Rhistory
 .RData
 .Ruserdata
+.log
 local
+.DS_Store

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2017-11-03  James Joseph Balamuta <balamut2@illinois.edu>
+
+    * inst/rmarkdown/templates/pdf/resources/template.tex: Added skip_final_break
+      toggle to allow users to opt out of \pnasbreak, which is on by default.
+    * inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd: Added example using
+      skip_final_break toggle.
+    * vignettes/pinp.Rmd: Idem
+	
+2017-11-02  Enrico Spinielli <enrico.spinielli@gmail.com>
+
+    * vignettes/pinp.Rmd: Typo
+	
 2017-10-31  Dirk Eddelbuettel  <edd@debian.org>
 
 	* inst/NEWS.Rd: Refer to pinp, not tint

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -87,7 +87,11 @@ $body$
 $if(acknowledgements)$
 \showacknow
 $endif$
-%\pnasbreak 
+
+$if(skip_final_break)$
+$else$
+\pnasbreak 
+$endif$
 
 $if(natbib)$
 $if(bibliography)$

--- a/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
@@ -60,6 +60,9 @@ fontsize: 9pt
 # Optional: Specify the depth of section number, default is 5
 #secnumdepth: 5
 
+# Optional: Skip inserting final break between acknowledgements, default is false
+skip_final_break: true
+
 # Optional: Bibliography 
 bibliography: pinp
 

--- a/vignettes/pinp.Rmd
+++ b/vignettes/pinp.Rmd
@@ -101,6 +101,9 @@ include-after: |
 # Optional: Enable a 'Draft' watermark on the document
 #watermark: true
 
+# Optional: Skip inserting final break between acknowledgements, default is false
+skip_final_break: true
+
 # Customize footer, eg by referencing the vignette
 footer_contents: "pinp Vignette"
 
@@ -208,7 +211,12 @@ An _optional_ selection (via values 1, 2, 3, ...) of section numbering depth,
 selectable only if `numbersections: true` is set.  Useful if you only want
 to number sections and subsections but not subsubsections and so on.
 
-  
+## `skip_final_break`
+
+An _optional_ selection (via value `true`) that avoids inserting a `\pnasbreak`
+at the end of the document. This is useful when dealing with float issues that
+may appear at the end of documents with acknowledgements and bibliographies.
+
 ## `bibliography`
 
 A field for an _optional_ selection of a Bibtex input file, extension


### PR DESCRIPTION
Adds an option `skip_final_break`. This option is disabled by default (e.g. `FALSE`) and, thus, `\pnasbreak` will now be included.

/ cc #44 