### PR TITLE
Updated: spacing around text is proportional to the papersize

### DIFF
--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -14,10 +14,18 @@ $if(tables)$
 \usepackage{longtable}
 $endif$
 
-% The geometry package layout settings need to be set here...
+% The geometry package layout settings need to be set here.
+% The adjustments are based on letter paper size (612x792pts)
 \geometry{layoutsize={0.95588\paperwidth,0.98864\paperheight},%
           layouthoffset=0.02206\paperwidth,%
-		  layoutvoffset=0.00568\paperheight}
+		  layoutvoffset=0.00568\paperheight,
+		  left=0.0629\paperwidth,%
+		  right=0.07026\paperwidth,%
+		  top=0.05429\paperheight,% 10pt provided by headsep
+		  bottom=0.0404\paperheight,%
+		  headheight=0pt,% No Header
+		  headsep=0.0126\paperheight,%
+		  footskip=0.0316\paperheight}
 
 $if(headercolor)$
 \definecolor{pinpblue}{HTML}{$headercolor$}

--- a/inst/rmarkdown/templates/pdf/skeleton/pinp.cls
+++ b/inst/rmarkdown/templates/pdf/skeleton/pinp.cls
@@ -206,14 +206,7 @@
 \RequirePackage[noend]{algpseudocode}
 \RequirePackage{changepage}
 \RequirePackage[twoside,%
-				includeheadfoot,
-                left=38.5pt,%
-                right=43pt,%
-                top=43pt,% 10pt provided by headsep
-                bottom=32pt,%
-                headheight=0pt,% No Header
-                headsep=10pt,%
-                footskip=25pt]{geometry}
+				includeheadfoot]{geometry}
 \RequirePackage[labelfont={bf,sf},%
                 labelsep=period,%
                 figurename=Fig.]{caption}

--- a/vignettes/pinp.Rmd
+++ b/vignettes/pinp.Rmd
@@ -287,7 +287,7 @@ be used around a wide table structure.
 
 ## widetext
 
-The `\begin{widetext*} ... \end{widetext*}` environment can be used to
+The `\begin{widetext} ... \end{widetext}` environment can be used to
 break text from two-column mode to one-column mode and back.
 
 


### PR DESCRIPTION
I adjusted the spacing around the text to be proportional to the paper size. I've attached the a5 and a3 (with 12pt font size) paper size examples of the vignette to help you decide what you want to do for this pull request.

Note that for graphs the chunk options should include `out.width="\\columnwidth"` especially for a3 (otherwise `pdflatex` just keep running for a long time [> 2 hours on my system]).

[pinp-a3paper.pdf](https://github.com/eddelbuettel/pinp/files/2107232/pinp-a3paper.pdf)
[pinp-a5paper.pdf](https://github.com/eddelbuettel/pinp/files/2107233/pinp-a5paper.pdf)

