### PR TITLE
Corrected to widetext in pinp.Rmd

### DIFF
--- a/vignettes/pinp.Rmd
+++ b/vignettes/pinp.Rmd
@@ -287,7 +287,7 @@ be used around a wide table structure.
 
 ## widetext
 
-The `\begin{widetext*} ... \end{widetext*}` environment can be used to
+The `\begin{widetext} ... \end{widetext}` environment can be used to
 break text from two-column mode to one-column mode and back.
 
 


### PR DESCRIPTION
fixes #56

eddelbuettel/pinp#56 - Corrected to `widetext` from `widetext*` in pinp.Rmd 