### PR TITLE
support collapse mode

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2018-07-14  Dirk Eddelbuettel  <edd@debian.org>
+
+	* R/pinp.R (pinp): Added support for 'collapse' option via yaml header
+	support collapse mode
+
+2018-06-08  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Release 0.0.5
+
 2018-06-07  Dirk Eddelbuettel  <edd@debian.org>
 
 	* vignettes/bib.tex: Split out of vignette as pandoc 2.* no longer
@@ -6,7 +15,7 @@
 
 2017-11-04  Dirk Eddelbuettel  <edd@debian.org>
 
-	* DESCRIPTION (Version, Date): New release
+	* DESCRIPTION (Version, Date): Release 0.0.4
 
 2017-11-03  Dirk Eddelbuettel  <edd@debian.org>
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pinp
 Type: Package
 Title: 'pinp' is not 'PNAS'
-Version: 0.0.5
-Date: 2018-06-08
+Version: 0.0.5.1
+Date: 2018-07-14
 Author: Dirk Eddelbuettel and James Balamuta
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: A 'PNAS'-alike style for 'rmarkdown', derived from the

--- a/R/pinp.R
+++ b/R/pinp.R
@@ -79,16 +79,19 @@
 #'
 #' Yihui Xie (2017). knitr: A General-Purpose Package for Dynamic Report Generation in R. R
 #' package version 1.17.
-pinp <- function(..., keep_tex = TRUE, citation_package = 'natbib') {
+pinp <- function(..., keep_tex = TRUE, citation_package = 'natbib', collapse = FALSE) {
 
     template <- system.file("rmarkdown", "templates", "pdf", "resources", "template.tex",
                             package="pinp")
     base <- inherit_pdf_document(..., template = template,
-                                 keep_tex = keep_tex, citation_package = citation_package)
+                                 keep_tex = keep_tex,
+                                 citation_package = citation_package)
 
     base$knitr$opts_chunk$prompt <- FALSE 	# changed from TRUE
     base$knitr$opts_chunk$comment <- '# '	# default to one hashmark
     base$knitr$opts_chunk$highlight <- TRUE  	# changed as well
+
+    base$knitr$opts_chunk$collapse <- collapse 	# allow override
 
     base$knitr$opts_chunk$dev.args <- list(pointsize = 9)  # from 11
     base$knitr$opts_chunk$fig.width <- 3.5 	# from 4.9 # 6.125" * 0.8, as in template
@@ -99,7 +102,7 @@ pinp <- function(..., keep_tex = TRUE, citation_package = 'natbib') {
         paste('\\begin{ShadedResult}\n\\begin{verbatim}\n', x,
               '\\end{verbatim}\n\\end{ShadedResult}\n', sep = '')
     }
-    base$knitr$knit_hooks$output  <- hook_output
+    if (!collapse) base$knitr$knit_hooks$output  <- hook_output
     base$knitr$knit_hooks$message <- hook_output
     base$knitr$knit_hooks$warning <- hook_output
 

--- a/inst/NEWS.Rd
+++ b/inst/NEWS.Rd
@@ -16,6 +16,7 @@
     \item Correct NEWS headers from 'tint' to 'pinp' (\ghit{45}).
     \item New front-matter variables \sQuote{skip_final_break} skips the
     \code{pnasbreak} on final page which back as default (\ghpr{47}).
+    \item Support option to collapse code and result blocks.
   }
 }
 


### PR DESCRIPTION
This brings the "collapsed" code and result look that works with the `tint` package to `pinp`.  Took a moment of headscratching and digging but works now.