### PR TITLE
date_subtitle -- a YAML option to have a custom string of text in subtitle

### DIFF
--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -62,7 +62,7 @@ $abstract$
 \end{abstract}
 
 $if(date_subtitle)$
-\dates{date_subtitle}
+\dates{$date_subtitle$}
 $else$
 \dates{This version was compiled on \today} 
 $endif$

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -61,7 +61,12 @@ $if(keywords)$ \keywords{ $for(keywords)$ $keywords$ $sep$| $endfor$ } $endif$
 $abstract$
 \end{abstract}
 
-\dates{This version was compiled on \today}
+$if(date_subtitle)$
+\dates{date_subtitle}
+$else$
+\dates{This version was compiled on \today} 
+$endif$
+
 $if(doi)$
 \doi{$doi$}
 $endif$

--- a/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
@@ -12,6 +12,11 @@ address:
     address: Institute of Smoke and Magic, University of Sometown, Sometown, XY, 12345
   - code: b
     address: Department of Neat Tricks, Whereever State University, Someplace, MC, 67890
+    
+# Optional: line of arbitrary text with additional information.
+# Could be used, for example, to mention the bibliographic info in a post-print.
+# If not specified, defaults to "This version was compiled on \today"
+#date_subtitle: Published in *Journal of Statistical Software*, 2018
 
 # For footer text  TODO(fold into template, allow free form two-authors)
 lead_author_surname: Author and Author
@@ -128,6 +133,7 @@ We support several options via the YAML header
   pages;
 - Setting a free-form author field used on the inside footer;
 - Optional _Draft_ watermarking;
+- Line of custom text in subtitle (`date_subtitle`) suitable to give publication info of the draft, e.g. journal name in a post-print.
 
 
 

--- a/vignettes/pinp.Rmd
+++ b/vignettes/pinp.Rmd
@@ -15,6 +15,11 @@ address:
   - code: b
     address: Depts of Informatics and Statistics, Univ. of Illinois at Urbana-Champaign; Champaign, IL, USA; \url{balamut2@illinois.edu}
 
+# Optional: line of arbitrary text with additional information.
+# Could be used, for example, to mention the bibliographic info in a post-print.
+# If not specified, defaults to "This version was compiled on \today"
+#date_subtitle: Published in *Journal of Statistical Software*, 2018
+
 # For footer text  TODO(fold into template, allow free form two-authors)
 lead_author_surname: Eddelbuettel and Balamuta
 
@@ -214,6 +219,9 @@ above the watermark.
 
 An character value delimited by quotes for something like _"mypackage
 Vignette"_ which will be shown in the footer.
+
+## `date_subtitle`
+An _optional_ free-form text string. Could be used, for example, to mention the bibliographic info in a post-print. If not specified, defaults to "This version was compiled on {current date}"
 
 
 # Code 


### PR DESCRIPTION
  instead of the default "This version was compiled on \today"