### PR TITLE
implemented document_date field 

### DIFF
--- a/R/pinp.R
+++ b/R/pinp.R
@@ -35,11 +35,20 @@
 #'   suffix can be omitted; defaut is no bibliography.}
 #'   \item{\code{doi}}{(Optional but recommended) A free-format entry
 #'   suitable for a doi or url referencing the document or its
-#'   underlying code.}  \item{\code{fontsize}}{(Optional) Document
+#'   underlying code.}  
+#'   \item{\code{fontsize}}{(Optional) Document
 #'   fontsize, default is 9pt.}
 #'   \item{\code{footer_contents}}{(Optional) A free-format entry for
 #'   text placed in the footer, useful to associate with a package or
 #'   volume, default is \sQuote{Package Vignette}.}
+#'   \item{\code{date_subtitle}}{(Optional) An _optional_ free-form text string.
+#'    Could be used, for example, to mention the bibliographic info in a 
+#'    post-print. If not specified, defaults to "This version was compiled on
+#'     {current date}"}
+#'   \item{\code{document_date}}{(Optional) An _optional_ free-form text string
+#'    designed to specify the date of the document. It can be useful for example
+#'     to specify the exact date of the publication in a post-print. If not
+#'      specified, defaults to the current date.}
 #'   \item{\code{headercolor}}{(Optional) Color code (in hexadecimal
 #'   notation) for the title and section headers, default is blue tone
 #'   matching the R logo: \code{185FAF}.}
@@ -47,9 +56,11 @@
 #'   document, supplied as a list.}
 #'   \item{\code{lead_author_surnames}}{(Optional but recommended) A
 #'   free-format entry for a short author description placed in the
-#'   footer.}  \item{\code{lineno}}{(Optional) Logical value to select
+#'   footer.}  
+#'   \item{\code{lineno}}{(Optional) Logical value to select
 #'   line number display, may only work in one-column mode, default is
-#'   false.}  \item{\code{linkcolor}}{(Optional) Color code (in
+#'   false.}  
+#'   \item{\code{linkcolor}}{(Optional) Color code (in
 #'   hexadecimal notation) for the urls and reference links, default
 #'   is a light blue tone from the PNAS style: \code{000065}.}
 #'   \item{\code{numbersections}}{(Optional) Logical value to select

--- a/R/pinp.R
+++ b/R/pinp.R
@@ -41,14 +41,14 @@
 #'   \item{\code{footer_contents}}{(Optional) A free-format entry for
 #'   text placed in the footer, useful to associate with a package or
 #'   volume, default is \sQuote{Package Vignette}.}
-#'   \item{\code{date_subtitle}}{(Optional) An _optional_ free-form text string.
-#'    Could be used, for example, to mention the bibliographic info in a 
-#'    post-print. If not specified, defaults to "This version was compiled on
-#'     {current date}"}
-#'   \item{\code{document_date}}{(Optional) An _optional_ free-form text string
-#'    designed to specify the date of the document. It can be useful for example
-#'     to specify the exact date of the publication in a post-print. If not
-#'      specified, defaults to the current date.}
+#'   \item{\code{date_subtitle}}{(Optional) A free-form text string
+#'   which be used to mention the bibliographic info in a post-print.
+#'   If not specified, defaults to "This version was compiled on
+#'   {current date}"}
+#'   \item{\code{document_date}}{(Optional) A free-form text string
+#'   designed to specify the date of the document. It can be useful for example
+#'   to specify the exact date of the publication in a post-print. If not
+#'   specified it defaults to the current date.}
 #'   \item{\code{headercolor}}{(Optional) Color code (in hexadecimal
 #'   notation) for the title and section headers, default is blue tone
 #'   matching the R logo: \code{185FAF}.}

--- a/inst/rmarkdown/templates/pdf/resources/template.tex
+++ b/inst/rmarkdown/templates/pdf/resources/template.tex
@@ -66,6 +66,10 @@ $else$
 \dates{This version was compiled on \today} 
 $endif$
 
+$if(document_date)$
+\documentdate{$document_date$}
+$endif$
+
 % initially we use doi so keep for backwards compatibility
 $if(doi)$
 \doifooter{$doi$}

--- a/inst/rmarkdown/templates/pdf/skeleton/pinp.cls
+++ b/inst/rmarkdown/templates/pdf/skeleton/pinp.cls
@@ -317,7 +317,7 @@
 
 \makeatletter
 \fancypagestyle{firststyle}{
-   \fancyfoot[R]{\footerfont \printpinpfootercontents\hspace{7pt}|\hspace{7pt}\textbf{\today}\hspace{7pt}|\hspace{7pt}\textbf{\thepage\textendash\pageref{LastPage}}}
+   \fancyfoot[R]{\footerfont \printpinpfootercontents\hspace{7pt}|\hspace{7pt}\textbf{\@ifundefined{@documentdate}{\today}{\@documentdate}}\hspace{7pt}|\hspace{7pt}\textbf{\thepage\textendash\pageref{LastPage}}}
    \fancyfoot[L]{\footerfont\@ifundefined{@doifooter}{}{\@doifooter}}
 }
 \makeatother
@@ -331,7 +331,7 @@
 \rfoot{}%
 \makeatletter
 \fancyfoot[LE]{\footerfont\textbf{\thepage}\hspace{7pt}|\hspace{7pt}\@ifundefined{@doifooter}{}{\@doifooter}}
-\fancyfoot[RO]{\footerfont \printpinpfootercontents\hspace{7pt}|\hspace{7pt}\textbf{\today}\hspace{7pt}|\hspace{7pt}\textbf{\thepage}}
+\fancyfoot[RO]{\footerfont \printpinpfootercontents\hspace{7pt}|\hspace{7pt}\textbf{\@ifundefined{@documentdate}{\today}{\@documentdate}}\hspace{7pt}|\hspace{7pt}\textbf{\thepage}}
 \fancyfoot[RE,LO]{\footerfont\@ifundefined{@leadauthor}{}{\@leadauthor}}
 
 % Use footer routine for line numbers
@@ -396,6 +396,7 @@
 \newcommand{\additionalelement}[1]{\def\@additionalelement{#1}}
 \newcommand{\dates}[1]{\def\@dates{#1}}
 \newcommand{\doifooter}[1]{\def\@doifooter{#1}}
+\newcommand{\documentdate}[1]{\def\@documentdate{#1}}
 \newcommand{\leadauthor}[1]{\def\@leadauthor{#1}}
 \newcommand{\etal}[1]{\def\@etal{#1}}
 \newcommand{\keywords}[1]{\def\@keywords{#1}}

--- a/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
+++ b/inst/rmarkdown/templates/pdf/skeleton/skeleton.Rmd
@@ -133,8 +133,10 @@ We support several options via the YAML header
   pages;
 - Setting a free-form author field used on the inside footer;
 - Optional _Draft_ watermark to be added to each page;
-- Line of custom text in subtitle (`date_subtitle`) suitable to give publication info of 
-the draft, e.g. journal name in a post-print. 
+- Line of custom text in subtitle (`date_subtitle`) suitable to give publication
+info of the draft, e.g. journal name in a post-print;
+- Document date that appears in the footer can be specified manually using
+`document_date`.
 
 
 

--- a/man/pinp.Rd
+++ b/man/pinp.Rd
@@ -48,11 +48,20 @@ alphabetical order) in the document metadata:
   suffix can be omitted; defaut is no bibliography.}
   \item{\code{doi}}{(Optional but recommended) A free-format entry
   suitable for a doi or url referencing the document or its
-  underlying code.}  \item{\code{fontsize}}{(Optional) Document
+  underlying code.}  
+  \item{\code{fontsize}}{(Optional) Document
   fontsize, default is 9pt.}
   \item{\code{footer_contents}}{(Optional) A free-format entry for
   text placed in the footer, useful to associate with a package or
   volume, default is \sQuote{Package Vignette}.}
+  \item{\code{date_subtitle}}{(Optional) A free-form text string
+  which be used to mention the bibliographic info in a post-print.
+  If not specified, defaults to "This version was compiled on
+  {current date}"}
+  \item{\code{document_date}}{(Optional) A free-form text string
+  designed to specify the date of the document. It can be useful for example
+  to specify the exact date of the publication in a post-print. If not
+  specified it defaults to the current date.}
   \item{\code{headercolor}}{(Optional) Color code (in hexadecimal
   notation) for the title and section headers, default is blue tone
   matching the R logo: \code{185FAF}.}
@@ -60,9 +69,11 @@ alphabetical order) in the document metadata:
   document, supplied as a list.}
   \item{\code{lead_author_surnames}}{(Optional but recommended) A
   free-format entry for a short author description placed in the
-  footer.}  \item{\code{lineno}}{(Optional) Logical value to select
+  footer.}  
+  \item{\code{lineno}}{(Optional) Logical value to select
   line number display, may only work in one-column mode, default is
-  false.}  \item{\code{linkcolor}}{(Optional) Color code (in
+  false.}  
+  \item{\code{linkcolor}}{(Optional) Color code (in
   hexadecimal notation) for the urls and reference links, default
   is a light blue tone from the PNAS style: \code{000065}.}
   \item{\code{numbersections}}{(Optional) Logical value to select

--- a/vignettes/pinp.Rmd
+++ b/vignettes/pinp.Rmd
@@ -229,6 +229,9 @@ An _optional_ free-form text string. Could be used, for example, to
 mention the bibliographic info in a post-print. If not specified,
 defaults to "This version was compiled on {current date}"
 
+## `document_date`
+An _optional_ free-form text string designed to specify the date of the document. It can be useful for example to specify the exact date of the publication in a post-print. If not specified, defaults to the current date.
+
 
 # Code 
 


### PR DESCRIPTION
Started from scratch
in response to the recent discussion in #63

**Discussion part**
Maybe there should be a bit more consistency between `date_subtitle` and `document_date`. In my view their behaviour can be a bit confusing since both default to `\today`. I'd suggest to rename `date_subtitle` into `subtitle` or `infoline` – just drop date from default in this line. The date of the document can stay only in the footer – freely specified as text with the new `document_date` YAML param or resolving to `\today` by default. What do you think? 