### PR TITLE
Update pinp.cls

### DIFF
--- a/inst/rmarkdown/templates/pdf/skeleton/pinp.cls
+++ b/inst/rmarkdown/templates/pdf/skeleton/pinp.cls
@@ -174,7 +174,7 @@
 \newcommand{\copyrightfont}{\normalfont\rmfamily\fontsize{6}{8}\selectfont}
 
 %% Set URL link color & font
-\renewcommand\UrlFont{\color{pnasbluetext}\sffamily}
+\renewcommand\UrlFont{\color{pnasbluetext}\normalfont\texttt}
 
 %% Author and affiliation
 \RequirePackage{authblk}


### PR DESCRIPTION
Changing the style of URL to normal text so that it looks the same as DOI links in the reference list.

Here is how it looked before. Note, I changes the fonts in my document. 
![](https://habrastorage.org/webt/fa/rc/kb/farckboox48272x9id0c-fx0ihk.png)

And this is after the fix
![](https://habrastorage.org/webt/6y/1l/q4/6y1lq4uxsbxdnviy9u28wdlr9ic.png)