### PR TITLE
add columns mode used by pandoc's :::::: and ::: blocks (closes #87)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .Ruserdata
 .log
 .DS_Store
+local

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+2020-09-27  Dirk Eddelbuettel  <edd@debian.org>
+
+	* DESCRIPTION (Version, Date): Roll minor version
+
+	* inst/rmarkdown/templates/pdf/skeleton/pinp.cls: Add columns mode
+	with a special nod of appreciation to Grant McDermott
+
 2020-09-11  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Roll minor version

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: pinp
 Type: Package
 Title: 'pinp' is not 'PNAS'
-Version: 0.0.9.1
-Date: 2020-09-11
+Version: 0.0.9.2
+Date: 2020-09-27
 Author: Dirk Eddelbuettel and James Balamuta
 Maintainer: Dirk Eddelbuettel <edd@debian.org>
 Description: A 'PNAS'-alike style for 'rmarkdown', derived from the

--- a/inst/rmarkdown/templates/pdf/skeleton/pinp.cls
+++ b/inst/rmarkdown/templates/pdf/skeleton/pinp.cls
@@ -5,7 +5,7 @@
 %%   as well as local changes 
 %%
 %% Dirk Eddelbuettel and James Balamuta 
-%% August - September 2017, September 2019
+%% August - September 2017, September 2019, September 2020
 %% 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % pnas-new.cls, v1.44, 2018/05/06
@@ -213,7 +213,25 @@
     }{}
   }
 \fi
-  
+
+%% Multi-column mode using pandoc's '::::::' blocks with ':::'
+%%
+%% The code snippet is borrowed with love from Grant McDermott's repo at
+%% https://github.com/grantmcdermott/two-col-test and slightly extended to
+%% fit 'flushed' without indentation, removing a makeatletter layer
+\newenvironment{columns}[1][]{}{}
+\newenvironment{column}[1]{\noindent\begin{minipage}[t]{#1}\ignorespaces}{%
+  \end{minipage}
+  \ifhmode\unskip\fi
+  \aftergroup\useignorespacesandallpars}
+\def\useignorespacesandallpars#1\ignorespaces\fi{%
+  #1\fi\ignorespacesandallpars}
+\def\ignorespacesandallpars{%
+  \@ifnextchar\par
+  {\expandafter\ignorespacesandallpars\@gobble}%
+  {}%
+}
+
 %% Copyright statement (not used)
 \newboolean{displaycopyright}
 \setboolean{displaycopyright}{false} % Confirmed as not required


### PR DESCRIPTION
See #87 for discussion.  Works as tested on the vignette that previously needed it in the header.